### PR TITLE
feat: implement simple TCP server that responds with PONG to clients

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,66 @@
+/**
+ * File : MemoraDB/src/main.c
+ * Last Update Author : Kei077
+ * Last Update : 07/16/2025
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+int main() {
+	// Disabling output buffering
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
+
+	int server_fd, client_addr_len;
+	struct sockaddr_in client_addr;
+	
+	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+
+	if (server_fd == -1) {
+		printf("Socket creation failed: %s...\n", strerror(errno));
+		return 1;
+	}
+
+	// INADRR_ANY Macro used to bind the socket to all interfaces not just a specific IP
+	struct sockaddr_in serv_addr = { .sin_family = AF_INET ,
+									 .sin_port = htons(6379),
+									 .sin_addr = { htonl(INADDR_ANY) },
+									};
+	
+	if (bind(server_fd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) != 0) {
+		printf("Bind failed: %s \n", strerror(errno));
+		return 1;
+	}
+	
+	int connection_backlog = 1;
+	if (listen(server_fd, connection_backlog) != 0) {
+		printf("Listen failed: %s \n", strerror(errno));
+		return 1;
+	}
+	
+	printf("Waiting for a client to connect...\n");
+	client_addr_len = sizeof(client_addr);
+	
+	int client_fd = accept(server_fd, (struct sockaddr *) &client_addr, &client_addr_len);
+	printf("Client connected\n");
+	
+    if(client_fd < 0){
+        printf("Accept failed: %s \n", strerror(errno));
+        return 1;
+    }
+
+    // Hardcoded response
+	const char *response = "+PONG\r\n";
+    send(client_fd, response, strlen(response),0);
+
+    close(client_fd);
+	close(server_fd);
+
+	return 0;
+}


### PR DESCRIPTION
feat: implement simple TCP server that responds with PONG to clients

- Created a simple TCP server on port 6379
- Listen for incoming connections and accept client 
- Send hardcoded "PONG" response to clients  