### PR TITLE
refactor(hashtable): replace global lock with per-bucket mutex array

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2,17 +2,17 @@
  * =====================================================
  * MemoraDB - In-Memory Database System
  * =====================================================
- * 
+ *
  * File                      : src/server/server.c
  * Module                    : MemoraDB Server
- * Last Updating Author      : shady0503
- * Last Update               : 02/10/2026
+ * Last Updating Author      : m0hamed541
+ * Last Update               : 03/08/2026
  * Version                   : 1.0.0
- * 
+ *
  * Description:
  *  Main MemoraDB server.
- * 
- * 
+ *
+ *
  * Copyright (c) 2025 MemoraDB Project
  * =====================================================
  */
@@ -33,7 +33,7 @@ void *handle_client(void *arg) {
 
     char buffer[BUFFER_SIZE];
     char *tokens[MAX_TOKENS];
-    
+
     while (1) {
         ssize_t bytes = recv(client_fd, buffer, sizeof(buffer)-1, 0);
         if (bytes <= 0) {
@@ -75,6 +75,8 @@ int main() {
 
     log_message(LOG_INFO, "MemoraDB Server started successfully.");
 
+    hashtable_lock_init();
+
     int server_fd;
     socklen_t client_addr_len;
     struct sockaddr_in client_addr;
@@ -84,10 +86,9 @@ int main() {
         log_message(LOG_ERROR, "Socket creation failed: %s", strerror(errno));
         return 1;
     }
-    
+
     int one = 1;
     setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-
 
     int port = parse_port_env("MEMORADB_PORT", 6379);
     const char *bind_ip = getenv("MEMORADB_BIND");
@@ -125,16 +126,16 @@ int main() {
 
         ClientContext *client_context = malloc(sizeof(ClientContext));
         if(!client_context){
-          log_message(LOG_ERROR, "Failed to allocate client context");
-          close(client_fd);
-          continue;
+            log_message(LOG_ERROR, "Failed to allocate client context");
+            close(client_fd);
+            continue;
         }
 
         client_context->client_fd = client_fd;
 
         if (inet_ntop(AF_INET, &client_addr.sin_addr, client_context->ip_address, sizeof(client_context->ip_address)) == NULL) {
-          log_message(LOG_ERROR, "Failed to convert client IP: %s", strerror(errno));
-          strncpy(client_context->ip_address, "unknown", sizeof(client_context->ip_address));
+            log_message(LOG_ERROR, "Failed to convert client IP: %s", strerror(errno));
+            strncpy(client_context->ip_address, "unknown", sizeof(client_context->ip_address));
         }
 
         client_context->port = ntohs(client_addr.sin_port);

--- a/src/utils/hashTable.c
+++ b/src/utils/hashTable.c
@@ -38,7 +38,13 @@ unsigned int hash(const char *key) {
     return h % TABLE_SIZE;
 }
 
-pthread_mutex_t hashtable_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t bucket_mutex[TABLE_SIZE];  // per bucket lock
+
+void hashtable_lock_init(void) {
+    for (int i = 0; i < TABLE_SIZE; i++) {
+        pthread_mutex_init(&bucket_mutex[i], NULL);
+    }
+}
 
 Entry *HASHTABLE[TABLE_SIZE] = {0};
 
@@ -49,9 +55,9 @@ long long current_millis() {
 }
 
 void set_value(const char *key, const char *value, long long px) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
     Entry *entry = HASHTABLE[idx];
+    pthread_mutex_lock(&bucket_mutex[idx]);
     long long expiry = (px > 0) ? current_millis() + px : 0;
 
     while (entry) {
@@ -66,7 +72,7 @@ void set_value(const char *key, const char *value, long long px) {
             entry->type = VALUE_STRING;
             entry->data.string_value = strdup(value);
             entry->expiry = expiry;
-            pthread_mutex_unlock(&hashtable_mutex);
+            pthread_mutex_unlock(&bucket_mutex[idx]);
             return;
         }
         entry = entry->next;
@@ -80,12 +86,12 @@ void set_value(const char *key, const char *value, long long px) {
     entry->expiry = expiry;
     entry->next = HASHTABLE[idx];
     HASHTABLE[idx] = entry;
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
 }
 
 const char *get_value(const char *key) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
+    pthread_mutex_lock(&bucket_mutex[idx]);
     Entry *prev = NULL;
     Entry *entry = HASHTABLE[idx];
     long long now = current_millis();
@@ -105,15 +111,15 @@ const char *get_value(const char *key) {
                     list_free(entry->data.list_value);
                 }
                 free(entry);
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             } else {
                 if (entry->type == VALUE_STRING) {
                     const char *result = entry->data.string_value;
-                    pthread_mutex_unlock(&hashtable_mutex);
+                    pthread_mutex_unlock(&bucket_mutex[idx]);
                     return result;
                 }
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             }
         }
@@ -121,28 +127,28 @@ const char *get_value(const char *key) {
         entry = entry->next;
     }
 
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
     return NULL;
 }
 
 List *get_or_create_list(const char *key) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
+    pthread_mutex_lock(&bucket_mutex[idx]);
     Entry *entry = HASHTABLE[idx];
     long long now = current_millis();
 
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
             if (entry->expiry > 0 && entry->expiry <= now) {
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             }
             if (entry->type == VALUE_LIST) {
                 List *list = entry->data.list_value;
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return list;
             } else {
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             }
         }
@@ -152,7 +158,7 @@ List *get_or_create_list(const char *key) {
     //-- Not found, create new list entry --//
     Entry *new_entry = malloc(sizeof(Entry));
     if (!new_entry) {
-        pthread_mutex_unlock(&hashtable_mutex);
+        pthread_mutex_unlock(&bucket_mutex[idx]);
         return NULL;
     }
     new_entry->key = strdup(key);
@@ -163,34 +169,34 @@ List *get_or_create_list(const char *key) {
     HASHTABLE[idx] = new_entry;
 
     List *list = new_entry->data.list_value;
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
     return list;
 }
 
 List *get_list_if_exists(const char *key) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
+    pthread_mutex_lock(&bucket_mutex[idx]);
     Entry *entry = HASHTABLE[idx];
     long long now = current_millis();
 
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
             if (entry->expiry > 0 && entry->expiry <= now) {
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             }
             if (entry->type == VALUE_LIST) {
                 List *list = entry->data.list_value;
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return list;
             } else {
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return NULL;
             }
         }
         entry = entry->next;
     }
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
     return NULL;
 }
 
@@ -199,8 +205,8 @@ List *get_list_if_exists(const char *key) {
  * Removes the entry from the linked list and frees all associated memory.
  */
 int delete_key(const char *key) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
+    pthread_mutex_lock(&bucket_mutex[idx]);
     Entry *prev = NULL;
     Entry *entry = HASHTABLE[idx];
 
@@ -219,26 +225,26 @@ int delete_key(const char *key) {
             }
             free(entry);
             
-            pthread_mutex_unlock(&hashtable_mutex);
+            pthread_mutex_unlock(&bucket_mutex[idx]);
             return 1;
         }
         prev = entry;
         entry = entry->next;
     }
     
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
     return 0;
 }
 
 const char *get_type(const char *key) {
-    pthread_mutex_lock(&hashtable_mutex);
     unsigned int idx = hash(key);
+    pthread_mutex_lock(&bucket_mutex[idx]);
     Entry *entry = HASHTABLE[idx];
     long long now = current_millis();
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
             if (entry->expiry > 0 && entry->expiry <= now) {
-                pthread_mutex_unlock(&hashtable_mutex);
+                pthread_mutex_unlock(&bucket_mutex[idx]);
                 return "none"; 
             }
             const char *typeStr = "none";
@@ -247,11 +253,11 @@ const char *get_type(const char *key) {
             } else if (entry->type == VALUE_LIST) {
                 typeStr = "list";
             }
-            pthread_mutex_unlock(&hashtable_mutex);
+            pthread_mutex_unlock(&bucket_mutex[idx]);
             return typeStr;
         }
         entry = entry->next;
     }
-    pthread_mutex_unlock(&hashtable_mutex);
+    pthread_mutex_unlock(&bucket_mutex[idx]);
     return "none";
 }

--- a/src/utils/hashTable.c
+++ b/src/utils/hashTable.c
@@ -5,8 +5,8 @@
  * 
  * File                      : src/utils/hashTable.c
  * Module                    : Hash Table
- * Last Updating Author      : youssefbouraoui1
- * Last Update               : 02/08/2026
+ * Last Updating Author      : m0hamed541
+ * Last Update               : 03/08/2026
  * Version                   : 1.0.0
  * 
  * Description:

--- a/src/utils/hashTable.h
+++ b/src/utils/hashTable.h
@@ -5,8 +5,8 @@
  *
  * File                      : src/utils/hashTable.h
  * Module                    : Hash Table
- * Last Updating Author      : youssefbouraoui1
- * Last Update               : 02/08/2026
+ * Last Updating Author      : m0hamed541
+ * Last Update               : 03/16/2026
  * Version                   : 1.0.0
  *
  * Description:
@@ -49,6 +49,16 @@ typedef struct Entry {
 extern Entry *HASHTABLE[TABLE_SIZE];
 extern pthread_mutex_t bucket_mutex[TABLE_SIZE];
 
+/**
+ * @brief Initialize all mutexes for the hash table buckets.
+ *
+ * This function iterates overy every bycket in the hash table
+ * initializes its associated mutex.
+ * 
+ * @note Not thread safe and must be called during single threaded
+ * initialization.
+ * 
+ */
 void hashtable_lock_init(void);
 
 /**

--- a/src/utils/hashTable.h
+++ b/src/utils/hashTable.h
@@ -2,16 +2,16 @@
  * =====================================================
  * MemoraDB - In-Memory Database System
  * =====================================================
- * 
+ *
  * File                      : src/utils/hashTable.h
  * Module                    : Hash Table
  * Last Updating Author      : youssefbouraoui1
  * Last Update               : 02/08/2026
  * Version                   : 1.0.0
- * 
+ *
  * Description:
  *  Header for simple hash table for MemoraDB key-value storage.
- * 
+ *
  * Copyright (c) 2025 MemoraDB Project
  * =====================================================
  */
@@ -47,13 +47,16 @@ typedef struct Entry {
 /* ============================================================ */
 
 extern Entry *HASHTABLE[TABLE_SIZE];
+extern pthread_mutex_t bucket_mutex[TABLE_SIZE];
+
+void hashtable_lock_init(void);
 
 /**
  * @brief Hash function to compute the index for a given key.
- * 
+ *
  * This function uses a simple hash algorithm to convert a string key
  * into an unsigned integer index suitable for use in the hash table.
- * 
+ *
  * @param key The key to hash.
  * @return The computed hash index.
  */
@@ -61,7 +64,7 @@ unsigned int hash(const char *key);
 
 /**
  * @brief Set a string value in the hash table.
- * 
+ *
  * @param key The key to set.
  * @param value The string value to associate with the key.
  * @param px Expiry time in milliseconds (0 for no expiry).
@@ -70,7 +73,7 @@ void set_value(const char *key, const char *value, long long px);
 
 /**
  * @brief Get a string value from the hash table.
- * 
+ *
  * @param key The key to retrieve.
  * @return The string value, or NULL if not found or expired.
  */
@@ -106,7 +109,7 @@ long long current_millis(void);
 
 /**
  * @brief Get the type of the value at key.
- * 
+ *
  * @param key The key to lookup.
  * @return "string", "list", or "none" if not found.
  */

--- a/tests/test_hashtable.c
+++ b/tests/test_hashtable.c
@@ -2,17 +2,18 @@
  * =====================================================
  * MemoraDB - In-Memory Database System
  * =====================================================
- * 
+ *
  * File                      : tests/test_hashtable.c
  * Module                    : Hash Table Unit Tests
- * Last Updating Author      : sch0penheimer
- * Last Update               : 2025/31/07
+ * Last Updating Author      : m0hamed541
+ * Last Update               : 03/08/2026
  * Version                   : 1.0.0
- * 
+ *
  * Description:
  *  Unit tests for hash table operations including SET, GET, TTL functionality.
  *  Tests direct hashtable operations without server communication.
- * 
+ *
+ * Latest edits : call void init_lock_table(void)
  * Copyright (c) 2025 MemoraDB Project
  * =====================================================
  */
@@ -25,10 +26,10 @@
 
 void test_basic_set_get() {
     printf("Testing basic SET/GET operations...\n");
-    
+
     set_value("test_key", "test_value", 0);
     const char *result = get_value("test_key");
-    
+
     TEST_ASSERT(result != NULL, "GET should return non-NULL value");
     TEST_ASSERT(strcmp(result, "test_value") == 0, "GET should return correct value");
     TEST_SUCCESS("Basic SET/GET test passed");
@@ -36,56 +37,57 @@ void test_basic_set_get() {
 
 void test_key_expiry() {
     printf("Testing key expiry with TTL...\n");
-    
+
     //-- Set key with 100ms expiry --//
     set_value("expiry_key", "expiry_value", 100);
-    
+
     //-- Should exist immediately --//
     const char *result = get_value("expiry_key");
     TEST_ASSERT(result != NULL, "Key should exist immediately after SET");
     TEST_ASSERT(strcmp(result, "expiry_value") == 0, "Key should have correct value");
-    
+
     //-- Wait for expiry --//
     usleep(110000);
 
     //-- Should be expired --//
     result = get_value("expiry_key");
     TEST_ASSERT(result == NULL, "Key should be expired after TTL");
-    
+
     TEST_SUCCESS("Key expiry test passed");
 }
 
 void test_key_overwrite() {
     printf("Testing key overwrite...\n");
-    
+
     set_value("overwrite_key", "original_value", 0);
     set_value("overwrite_key", "new_value", 0);
-    
+
     const char *result = get_value("overwrite_key");
     TEST_ASSERT(result != NULL, "Overwritten key should exist");
     TEST_ASSERT(strcmp(result, "new_value") == 0, "Key should have new value");
-    
+
     TEST_SUCCESS("Key overwrite test passed");
 }
 
 void test_nonexistent_key() {
     printf("Testing nonexistent key...\n");
-    
+
     const char *result = get_value("nonexistent_key");
     TEST_ASSERT(result == NULL, "Nonexistent key should return NULL");
-    
+
     TEST_SUCCESS("Nonexistent key test passed");
 }
 
 int main() {
+    hashtable_lock_init();
     init_test_framework();
     printf("=== Hash Table Tests ===\n");
-    
+
     test_basic_set_get();
     test_key_expiry();
     test_key_overwrite();
     test_nonexistent_key();
-    
+
     save_test_results();
     return total_tests_failed > 0 ? 1 : 0;
 }


### PR DESCRIPTION
## refactor(hashtable): introduce per-bucket mutex locking

### summary
replace previous global locking mechanism with a per-bucket mutex array.

( this PR Closes: #74 )

---

### motivation
the previous implementation relied on a single global mutex protecting the entire hashtable. as a result, operations on unrelated keys were forced to wait on the same lock, creating unnecessary contention and significantly reducing efficiency in multithreaded scenarios.

using per-bucket locking sacrifices memory to improve concurrency by allowing operations on different buckets to run in parallel.

---

### changes

#### `hashTable.h`
- added `extern pthread_mutex_t bucket_mutex[TABLE_SIZE]`
- added declaration for `hashtable_init()`

#### `hashTable.c`
- defined `bucket_mutex[TABLE_SIZE]`
- implemented `hashtable_init()` to initialize all bucket mutexes

#### `server.c`
- added `hashtable_init()` call in `main()` before creating the server socket


C
